### PR TITLE
minor loading fix

### DIFF
--- a/src/server/Library/UI/Panel/Scripts/Core/init.meta.json
+++ b/src/server/Library/UI/Panel/Scripts/Core/init.meta.json
@@ -1,5 +1,2 @@
 {
-	"properties": {
-		"Disabled": true
-	}
 }

--- a/src/server/init.server.lua
+++ b/src/server/init.server.lua
@@ -19,8 +19,12 @@ local currentTheme = nil
 local isPlayerAddedFired = false
 
 local function newWarn(...)
-    if systemPackages.Settings.Misc.IsVerbose then
-        warn("Commander; " .. ...)
+    if systemPackages.Settings then
+        if systemPackages.Settings.Misc.IsVerbose then
+            warn("Commander; " .. ...)
+        end
+    else
+        warn(debug.traceback("Something unexpectedly tried to read a value from Settings before it has loaded ",2))
     end
 end
 


### PR DESCRIPTION
now throws a warning if the warn func is called without settings being loaded prior (useful for debugging as it doesn't stop the threads execution and instead throws a warning)

as for the minor property change that's because it wouldn't let me startup rojo without removing it so uhhh feel free to remove that ig
